### PR TITLE
Add a devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/debian
+{
+	"name": "Debian",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/base:bookworm@sha256:691e49f9553c20cd13dc3030daec47ad81a124a42049264ead32531d3af9f41f",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1.4.2": {},
+		"ghcr.io/devcontainers/features/github-cli:1.0.11": {},
+		"ghcr.io/devcontainers/features/node:1.4.0": {},
+		"ghcr.io/devcontainers-contrib/features/act:1.0.14": {},
+		"ghcr.io/devcontainers-contrib/features/pre-commit:2.0.17": {}
+	},
+
+	"postCreateCommand": {
+		"Initialize pre-commit environment": "nohup sh -c 'pre-commit install -f --install-hooks &' > /dev/null"
+	},
+
+	"postAttachCommand": {
+		// Note: VSCode will fail to clone the dotfiles repository if there's a
+		// conflict in the known_hosts file, but the error message in very
+		// misleading.
+		"Update dotfiles": "chezmoi update --apply --verbose --force"
+	}
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,18 +19,46 @@
   "lockFileMaintenance": {"enabled": true},
   "packageRules": [
     {
-      // Update golang tag in dockerfile & golang version in workflows in a
-      // single PR"
+      "description": "Update golang tag in dockerfile & golang version in workflows in a single PR",
       "groupName": "golang version",
       "matchDepNames": [
         "^golang$"
       ]
     },
     {
-      // Renovate's packages update too frequently, so we only schedule updates
-      // once a week to keep the noise down
+      "description": "Update devcontainer images in a single PR",
+      "groupName": "devcontainer",
+      "matchFileNames": [".devcontainer/devcontainer.json"]
+    },
+    {
+      "description": "Update renovatebot/pre-commit-hooks weekly to decrease noise",
       "matchPackageNames": ["renovatebot/pre-commit-hooks"],
       "schedule": ["before 9am on monday"]
+    }
+  ],
+  "regexManagers": [
+    {
+      "customType": "regex",
+      "description": "devcontainer base image",
+      "fileMatch": [
+        "^.devcontainer/devcontainer.json$"
+      ],
+      "matchStrings": [
+        "\"image\"\\s*:\\s*\"(?<depName>.*?):(?<currentValue>.*?)(@(?<currentDigest>sha256:[a-f0-9]+))?\""
+      ],
+      "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "devcontainer feature images",
+      "fileMatch": [
+        "^.devcontainer/devcontainer.json$"
+      ],
+      "matchStrings": [
+        // devcontainer features don't support sha256 digests
+        "\"(?<depName>.*?):(?<currentValue>.*?)\"\\s*:\\s*"
+      ],
+      "datasourceTemplate": "docker"
     }
   ],
   // "schedule": [

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,10 @@ repos:
       - id: check-added-large-files  # Prevents giant files from being committed
       - id: check-docstring-first    # Prevent code before docstring
       - id: check-json               # Check that JSON files are valid
+        exclude: |
+          (?x)^(
+                .devcontainer/devcontainer.json
+          )$
       - id: check-merge-conflict     # Check merge conflict strings
       - id: check-symlinks           # Ensure symlinks have a valid target
       - id: check-toml               # Ensure toml files are valid
@@ -103,3 +107,9 @@ repos:
       - id: detect-secrets
       #  args: ['--baseline', '.secrets.baseline']
       #  exclude: package.lock.json
+
+  - repo: https://gitlab.com/bmares/check-json5
+    rev: "v1.0.0"
+    hooks:
+      # Check that JSON files are valid JSON5
+      - id: check-json5


### PR DESCRIPTION
- Update renovate configuration to auto-update the devcontainer images
- Adjust pre-commit to only try parsing devcontainer.json as json5
  (i.e., allow comments)

Signed-off-by: John Strunk <john.strunk@gmail.com>