### PR TITLE
Update renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -53,6 +53,9 @@
       ]
     }
   ],
+  "prConcurrentLimit": 3,
+  "prHourlyLimit": 0,
+  "rebaseWhen": "behind-base-branch",
   // "schedule": ["before 7am on Tuesday"],
   "semanticCommits": "disabled",
   "timezone": "America/New_York"


### PR DESCRIPTION
Added concurrent and hourly PR limits, and enabled rebasing when behind
base branch to improve Renovate workflow efficiency.

Signed-off-by: John Strunk <john.strunk@gmail.com>
