### PR TITLE
Update base image to Debian Trixie

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 	// https://github.com/devcontainers/templates/tree/main/src/debian
 	// Other base images: https://github.com/devcontainers/images
 	"name": "Debian",
-	"image": "mcr.microsoft.com/devcontainers/base:bookworm@sha256:ce2e9e611939e611b737362c045bb6d3449bb3efb84898525d724aace1737b90",
+	"image": "mcr.microsoft.com/devcontainers/base:trixie",
 	// Available features: https://containers.dev/features
 	"features": {
 		"ghcr.io/devcontainers/features/node:1.6.3": {},


### PR DESCRIPTION
This pull request makes a small change to the development container configuration, updating the base image from Debian "bookworm" to "trixie" in the `.devcontainer/devcontainer.json` file. This ensures the dev container uses the latest Debian release for improved support and features.