### PR TITLE
Update renovate config for devcontainer image pinning

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,6 +31,16 @@
       ]
     },
     {
+      "description": "Pin devcontainer image digests",
+      "matchManagers": [
+        "devcontainer"
+      ],
+      "matchDepTypes": [
+        "image"
+      ],
+      "pinDigests": true
+    },
+    {
       // Features can be pinned, but they don't support the standard :tag@sha256
       // syntax. It's just one or the other.
       // See: https://github.com/devcontainers/cli/issues/825
@@ -53,9 +63,9 @@
       ]
     }
   ],
-  "prConcurrentLimit": 3,
+  "prConcurrentLimit": 5,
   "prHourlyLimit": 0,
-  "rebaseWhen": "behind-base-branch",
+  "rebaseWhen": "auto",
   // "schedule": ["before 7am on Tuesday"],
   "semanticCommits": "disabled",
   "timezone": "America/New_York"


### PR DESCRIPTION
This pull request updates the Renovate configuration to improve dependency management for the project. The main changes include pinning devcontainer image digests and adjusting Renovate's pull request limits and rebase strategy.

**Dependency management improvements:**

* Added a new rule to pin devcontainer image digests, ensuring more reliable and reproducible builds. (`.github/renovate.json5`)

**Renovate configuration updates:**

* Increased the concurrent pull request limit from 3 to 5 to allow more updates to be processed simultaneously. (`.github/renovate.json5`)
* Changed the rebase strategy from "behind-base-branch" to "auto" to let Renovate decide when to rebase, potentially improving PR freshness. (`.github/renovate.json5`)