### PR TITLE
Update devcontainer image and add corepack enable

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,10 @@
 {
     // For format details, see https://aka.ms/devcontainer.json.
-    // For config options, see the README at:
-    // https://github.com/devcontainers/templates/tree/main/src/debian
-    // Other base images: https://github.com/devcontainers/images
     "name": "Debian",
-    "image": "mcr.microsoft.com/devcontainers/base:trixie@sha256:4fe00dc6fc270f2239b6ec06bf35b7c3db6b52be07d22e3098309b7fe8769243",
+    // https://github.com/devcontainers/images/tree/main/src/base-debian
+    // The :debian tag is the latest Debian stable release
+    // Other base images: https://github.com/devcontainers/images
+    "image": "mcr.microsoft.com/devcontainers/base:debian@sha256:4fe00dc6fc270f2239b6ec06bf35b7c3db6b52be07d22e3098309b7fe8769243",
     // Available features: https://containers.dev/features
     "features": {
         "ghcr.io/devcontainers/features/github-cli:1.0.15": {},
@@ -20,6 +20,7 @@
     "postCreateCommand": {
         // Install pre-commit hooks in the background since they can take a
         // while, and we want to minimize waiting during `git commit`
-        "Initialize pre-commit environment": "nohup sh -c 'pre-commit install -f --install-hooks &' < /dev/null > /dev/null 2>&1"
+        "Initialize pre-commit environment": "nohup sh -c 'pre-commit install -f --install-hooks &' < /dev/null > /dev/null 2>&1",
+		"Enable corepack": "corepack enable"
     }
 }


### PR DESCRIPTION
Update the base image to the latest Debian stable release and add a command
to enable corepack in the post-create process. This change ensures that the
development container uses the most recent stable Debian version and
enables corepack for better package management.

Signed-off-by: John Strunk <john.strunk@gmail.com>
