### PR TITLE
Move linting instructions to MADR and update related files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,21 +12,9 @@ understanding the rationale behind various design choices and provide context
 for future development.
 **All changes must be consistent with these documents.**
 
-Before making changes or adding new code:
+Before making changes to the repository or adding new code:
 
 - Review all existing decision records and feature descriptions in the `design/`
   directory. Changes and additions must align with these documents.
 - If requirements or instructions from the user are ambiguous or incomplete,
   ask clarifying questions before proceeding.
-
-## File linting
-
-- **Files must be properly linted** - After making changes to *any files* in
-this repository, ensure that all linting checks pass. Use the script
-[`.github/lint-all.sh`](lint-all.sh) to check for problems. If any issues are
-found, fix them, and re-run the script. Continue to iterate until no issues
-are found. **This must be done any time files are modified and before telling
-the user that changes are complete.**
-
-- **All markdown files must comply with markdownlint rules** - Use the output
-  of `.github/lint-all.sh` to identify markdownlint issues, then fix them.

--- a/.github/prompts/madr.prompt.md
+++ b/.github/prompts/madr.prompt.md
@@ -2,9 +2,24 @@
 description: Document a new architectural decision
 mode: agent
 ---
-# Document a new architectural decision
 
-Given the decision description provided as an argument, do this:
+# Documenting a New Architectural Decision
+
+The user input to you can be provided directly by the agent or as a command
+argument - you **MUST** consider it before proceeding with the prompt (if not
+empty).
+
+User input:
+
+$ARGUMENTS
+
+The text the user typed after `/madr` in the triggering message **is** the
+title of the decision record. Assume you always have it available in this
+conversation even if `$ARGUMENTS` appears literally below. Do not ask the user
+to repeat it unless they provided an empty command.
+
+Follow these steps to create a new MADR (Markdown Architectural Decision
+Record) file in the `design/` directory.
 
 - Run the script `design/new-record.sh -m "$ARGUMENTS"` from reporoot and
   parse its JSON output for the filename.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
             "matchCommandLine": true
         },
         "./design/new-record.sh": true,
-        "design/new-record.sh": true
+        "design/new-record.sh": true,
+        "bash design/new-record.sh": true
     }
 }

--- a/design/0001-madr-linting-requirements-for-all.md
+++ b/design/0001-madr-linting-requirements-for-all.md
@@ -1,0 +1,40 @@
+# Linting requirements for all files
+
+## Context and problem statement
+
+By enforcing linting standards, the files in the repository will have a
+uniform appearance, making it easier for developers to understand and navigate
+the codebase. Consistent formatting and code style reduce cognitive load,
+prevent style-related merge conflicts, and help maintain code quality as the
+project grows.
+
+## Decision and justification
+
+All files in the repository must conform to the project's linting standards at
+all times.
+
+The `.github/lint-all.sh` script is provided to perform linting across the
+entire repository. Any time changes are made to any file, this script must be
+run, and all resulting errors and warnings must be immediately fixed before
+changes are committed or merged. When fixing linting errors, care must be
+taken to not alter the semantic meaning of the file—only formatting, style, or
+other linting issues should be addressed, without changing the actual behavior
+or content of the file. This ensures that the codebase remains consistently
+linted and free of style violations.
+
+## Other options considered
+
+Other options considered:
+
+- Relying on individual developer editors or IDEs to enforce linting: This
+  approach is inconsistent and can lead to style drift over time.
+- Running linting only on staged or tracked files: This may miss new or
+  untracked files, leading to inconsistent code quality.
+
+## Additional information
+
+Related resources:
+
+- [`design/README.md`](README.md): Overview of design and decision records
+- [`.github/lint-all.sh`](../.github/lint-all.sh): Linting script referenced
+in this decision


### PR DESCRIPTION
- Moved linting instructions from `.github/copilot-instructions.md` to a
new MADR (`design/0001-madr-linting-requirements-for-all.md`) to emphasize
their importance and provide more context.
- Updated `.github/copilot-instructions.md` to focus on the review process
and clarifying requirements.
- Enhanced `.github/prompts/madr.prompt.md` to better handle user input and
provide clearer instructions for creating new MADR files.
- Updated `.vscode/settings.json` to include the new script path for
linting.
- Added a new MADR to document the linting requirements and justify the
decision to enforce consistent formatting and code style across the
repository.

Signed-off-by: John Strunk <john.strunk@gmail.com>
