### PR TITLE
chore(renovate): configure custom regex managers and lock package versions in install-packages.sh

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -15,10 +15,10 @@
       "resolved": "ghcr.io/devcontainers-extra/features/uv@sha256:1ac5b9f17a9e9e745933d0ac2ecf758e06ed3da4423cd22c94cce4d482fd2dd8",
       "integrity": "sha256:1ac5b9f17a9e9e745933d0ac2ecf758e06ed3da4423cd22c94cce4d482fd2dd8"
     },
-    "ghcr.io/devcontainers/features/docker-in-docker:3.0.1": {
-      "version": "3.0.1",
-      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:ca2508495b01ba29eba93e8153772a2daa65eaa86471cc6863fe2a3d21933df9",
-      "integrity": "sha256:ca2508495b01ba29eba93e8153772a2daa65eaa86471cc6863fe2a3d21933df9"
+    "ghcr.io/devcontainers/features/docker-in-docker:3.1.0": {
+      "version": "3.1.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:62e04ec83d944da4fd2830f68a677d1f5466c0654aea1e4baa30232d16029ac1",
+      "integrity": "sha256:62e04ec83d944da4fd2830f68a677d1f5466c0654aea1e4baa30232d16029ac1"
     },
     "ghcr.io/devcontainers/features/github-cli:1.1.0": {
       "version": "1.1.0",

--- a/.devcontainer/install-packages.sh
+++ b/.devcontainer/install-packages.sh
@@ -17,21 +17,32 @@ sudo pkill -x dockerd || true
 sudo pkill -x containerd || true
 sudo /usr/local/share/docker-init.sh
 
+# Package versions to be managed by Renovate
+# renovate: datasource=npm depName=@bitwarden/cli
+BITWARDEN_CLI_VERSION="2026.5.0"
+# renovate: datasource=npm depName=markdownlint-cli2
+MARKDOWNLINT_CLI2_VERSION="0.22.1"
+# renovate: datasource=npm depName=@playwright/cli
+PLAYWRIGHT_CLI_VERSION="0.1.13"
+# renovate: datasource=npm depName=playwright
+PLAYWRIGHT_VERSION="1.60.0"
+# renovate: datasource=pypi depName=ruff
+RUFF_VERSION="0.15.18"
+
 # Install Google Antigravity CLI
 curl -fsSL https://antigravity.google/cli/install.sh | bash
 
 # Install npm tools
 npm install -g --no-fund \
-    @bitwarden/cli@2026.5.0 \
-    markdownlint-cli2@0.22.1 \
-    @playwright/cli@0.1.13
+    @bitwarden/cli@"$BITWARDEN_CLI_VERSION" \
+    markdownlint-cli2@"$MARKDOWNLINT_CLI2_VERSION" \
+    @playwright/cli@"$PLAYWRIGHT_CLI_VERSION"
 
-npx -y playwright@1.60.0 install --with-deps
+npx -y playwright@"$PLAYWRIGHT_VERSION" install --with-deps
 
-# shellcheck disable=SC2043
-for pkg in ruff; do
-   uv tool install $pkg;
-done
+
+uv tool install ruff@"$RUFF_VERSION"
+
 
 
 # # Install skills

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,32 +13,34 @@
   ],
   // Files to ignore
   "ignorePaths": [
-    ".venv"
+    ".venv",
   ],
   "labels": [
-    "dependencies"
+    "dependencies",
   ],
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": true,
   },
+  "minimumReleaseAge": "10 days",
+  "rangeStrategy": "pin",
   "packageRules": [
     {
       "description": "Update golang tag in dockerfile & golang version in workflows in a single PR",
       "groupName": "golang version",
       "matchDepNames": [
         "go",
-        "golang"
-      ]
+        "golang",
+      ],
     },
     {
       "description": "Pin devcontainer image digests",
       "matchManagers": [
-        "devcontainer"
+        "devcontainer",
       ],
       "matchDepTypes": [
-        "image"
+        "image",
       ],
-      "pinDigests": true
+      "pinDigests": true,
     },
     {
       // Features can be pinned, but they don't support the standard :tag@sha256
@@ -46,27 +48,52 @@
       // See: https://github.com/devcontainers/cli/issues/825
       "description": "Devcontainer 'features' don't support digest pinning",
       "matchManagers": [
-        "devcontainer"
+        "devcontainer",
       ],
       "matchDepTypes": [
-        "feature"
+        "feature",
       ],
-      "pinDigests": false
+      "pinDigests": false,
     },
     {
       "description": "Update renovatebot/pre-commit-hooks weekly to decrease noise",
       "matchPackageNames": [
-        "renovatebot/pre-commit-hooks"
+        "renovatebot/pre-commit-hooks",
       ],
       "schedule": [
-        "before 9am on monday"
-      ]
-    }
+        "before 9am on monday",
+      ],
+    },
+    {
+      // Container registries often lack releaseTimestamp metadata, which
+      // causes the default timestamp-required behaviour to mark every
+      // digest pin as permanently pending.  Fall back to the image
+      // creation date so the age check can actually pass.
+      "description": "Use image creation date for container age checks",
+      "matchCategories": [
+        "docker",
+      ],
+      "minimumReleaseAgeBehaviour": "creation-date-fallback",
+    },
+    {
+      "description": "Keep overrides as ranges — they are security/compat floors",
+      "matchDepTypes": [
+        "overrides",
+      ],
+      "rangeStrategy": "replace",
+    },
   ],
   "prConcurrentLimit": 5,
   "prHourlyLimit": 0,
   "rebaseWhen": "auto",
   // "schedule": ["before 7am on Tuesday"],
   "semanticCommits": "disabled",
-  "timezone": "America/New_York"
+  "timezone": "America/New_York",
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": "0 days",
+    "labels": [
+      "dependencies",
+      "security",
+    ],
+  },
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -89,6 +89,22 @@
   // "schedule": ["before 7am on Tuesday"],
   "semanticCommits": "disabled",
   "timezone": "America/New_York",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/\\.sh$/"],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>[a-z-]+)\\s+depName=(?<depName>[a-zA-Z0-9/@_-]+)(?:\\s+versioning=(?<versioning>[a-z-]+))?\\s+[A-Z0-9_]+_VERSION=\"(?<currentValue>[^\"]+)\""
+      ]
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/\\.sh$/"],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>[a-z-]+)\\s+depName=(?<depName>[a-zA-Z0-9/@_-]+)(?:\\s+versioning=(?<versioning>[a-z-]+))?\\s+[^#\\n]*?@(?<currentValue>[a-zA-Z0-9.-]+)"
+      ]
+    }
+  ],
   "vulnerabilityAlerts": {
     "minimumReleaseAge": "0 days",
     "labels": [


### PR DESCRIPTION
This PR configures Renovate to auto-upgrade package versions in `install-packages.sh` by:
1. Setting up custom regex managers in `.github/renovate.json5` matching comment annotations.
2. Annotating and pinning versions of `@bitwarden/cli`, `markdownlint-cli2`, `@playwright/cli`, `playwright`, and `ruff` in `install-packages.sh`.